### PR TITLE
add create_model; update python soup-dil

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,16 @@ using SOUP-DIL dictionary learning-based regularization.
 that takes overlapping patches in an initial image
 and learns a dictionary and a set of sparse coefficients to represent these patches.
 
+#### Update
+
+Now we provide SOUP-DIL on Python, via [MIRTorch](https://github.com/guanhuaw/MIRTorch). This [Jupyter notebook](https://github.com/guanhuaw/MIRTorch/blob/master/examples/demo_dl.ipynb) illustrates the usage.
+
 
 ## Deep Supervised Learning-based Image Reconstruction
 
 The supervised learning approach used a training set generated from the
 [fastMRI project](https://fastmri.org/).
+
 * `Preprocessing.ipynb` provides an example of the data-preprocessing.
 * `MODL_DLMRI_Knee_vd.sh` gives an example of training the neural network.
 * The file `requirements.txt` denotes related Python packages.

--- a/Supervised learning/models/__init__.py
+++ b/Supervised learning/models/__init__.py
@@ -1,0 +1,40 @@
+import importlib
+from models.base_model import BaseModel
+
+
+def find_model_using_name(model_name):
+    # Given the option --model [modelname],
+    # the file "models/modelname_model.py"
+    # will be imported.
+    model_filename = "models." + model_name + "_model"
+    modellib = importlib.import_module(model_filename)
+
+    # In the file, the class called ModelNameModel() will
+    # be instantiated. It has to be a subclass of BaseModel,
+    # and it is case-insensitive.
+    model = None
+    target_model_name = model_name.replace('_', '') + 'model'
+    for name, cls in modellib.__dict__.items():
+        if name.lower() == target_model_name.lower() \
+                and issubclass(cls, BaseModel):
+            model = cls
+
+    if model is None:
+        print("In %s.py, there should be a subclass of BaseModel with class name that matches %s in lowercase." % (
+        model_filename, target_model_name))
+        exit(0)
+
+    return model
+
+
+def get_option_setter(model_name):
+    model_class = find_model_using_name(model_name)
+    return model_class.modify_commandline_options
+
+
+def create_model(opt):
+    model = find_model_using_name(opt.model)
+    instance = model()
+    instance.initialize(opt)
+    print("model [%s] was created" % (instance.name()))
+    return instance


### PR DESCRIPTION
We added the create_model corresponding to #4 . The readme now has a reference to python-based SOUP-DIL codes.